### PR TITLE
Adding support to keep both original and edited swaggers in configmaps & Handling resource level endpoints with sidecar deployment 

### DIFF
--- a/apim-operator/deploy/kubectl-extension/kubectl-add
+++ b/apim-operator/deploy/kubectl-extension/kubectl-add
@@ -74,9 +74,10 @@ then
         done
 
         apiName=$2
+        configmapName="$apiName-swagger"
 
         echo -e "\nCreating configmap with name "$apiName $namespace
-        kubectl create configmap $apiName $3 $namespace
+        kubectl create configmap $configmapName $3 $namespace
 
 
         if [ $? -eq 0 ]; then
@@ -89,7 +90,7 @@ metadata:
  name: "${apiName}"
 spec:
  definition:
-  configmapName: "${apiName}"
+  configmapName: "${configmapName}"
   type: swagger
  replicas: ${replicas}
  mode: privateJet

--- a/apim-operator/pkg/controller/api/api_controller.go
+++ b/apim-operator/pkg/controller/api/api_controller.go
@@ -469,17 +469,17 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	formattedSwagger := string(prettyJSON.Bytes())
 	//create configmap with modified swagger
-	swaggerConfMap := createConfigMap(apiConfigMapRef + "-mgw", swaggerDataFile, formattedSwagger, userNameSpace, owner)
+	swaggerConfMap := createConfigMap(apiConfigMapRef+"-mgw", swaggerDataFile, formattedSwagger, userNameSpace, owner)
 	log.Info("Creating swagger configmap for mgw")
-	_, errgetConf := getConfigmap(r, apiConfigMapRef + "-mgw", userNameSpace)
-	if errgetConf != nil && errors.IsNotFound(errgetConf){
+	_, errgetConf := getConfigmap(r, apiConfigMapRef+"-mgw", userNameSpace)
+	if errgetConf != nil && errors.IsNotFound(errgetConf) {
 		log.Info("swagger-mgw is not found. Hence creating new configmap")
 		errConf := r.client.Create(context.TODO(), swaggerConfMap)
 		if errConf != nil {
 			log.Error(err, "Error in mgw swagger configmap create")
 		}
 	} else if errgetConf != nil {
-		log.Error(errgetConf,"error getting swagger-mgw")
+		log.Error(errgetConf, "error getting swagger-mgw")
 	}
 
 	if isDefined == false && len(securityDef.Security) == 0 {
@@ -1025,13 +1025,13 @@ func mgwSwaggerHandler(r *ReconcileAPI, swagger *openapi3.Swagger, mode string, 
 	var resLevelEp = make(map[string]XMGWProductionEndpoints)
 	mapName := apiName + "-swagger-mgw"
 	//get mgw swagger if available
-	configmapOfNewSwagger, err := getConfigmap(r, mapName,userNameSpace)
-	if err != nil && errors.IsNotFound(err){
+	configmapOfNewSwagger, err := getConfigmap(r, mapName, userNameSpace)
+	if err != nil && errors.IsNotFound(err) {
 		log.Info("configmap for mgw swagger is not found.Creating a new configmap")
 		mgwSwagger = swagger
 	} else if err != nil {
-		log.Error(err,"error getting configmap of mgw swagger file")
-	}else {
+		log.Error(err, "error getting configmap of mgw swagger file")
+	} else {
 		for _, value := range configmapOfNewSwagger.Data {
 			editedSwaggerData = value
 		}
@@ -1109,7 +1109,7 @@ func mgwSwaggerHandler(r *ReconcileAPI, swagger *openapi3.Swagger, mode string, 
 								isServiceDef = true
 							}
 						} else {
-								endpointNames[endpointUrl.Hostname()] = endpointUrl.Hostname()
+							endpointNames[endpointUrl.Hostname()] = endpointUrl.Hostname()
 						}
 					}
 
@@ -1141,11 +1141,11 @@ func mgwSwaggerHandler(r *ReconcileAPI, swagger *openapi3.Swagger, mode string, 
 					err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: userNameSpace,
 						Name: endPoint}, currentService)
 					erCr := r.client.Get(context.TODO(), types.NamespacedName{Namespace: userNameSpace, Name: endPoint}, targetEndpointCr)
-					if err != nil && errors.IsNotFound(err) && mode != sidecar{
+					if err != nil && errors.IsNotFound(err) && mode != sidecar {
 						log.Error(err, "Service is not found")
 					} else if erCr != nil && errors.IsNotFound(erCr) {
 						log.Error(err, "targetendpoint CRD object is not found")
-					} else if err != nil && mode != sidecar{
+					} else if err != nil && mode != sidecar {
 						log.Error(err, "Error in getting service")
 					} else if erCr != nil {
 						log.Error(err, "Error in getting targetendpoint CRD object")
@@ -1190,7 +1190,7 @@ func mgwSwaggerHandler(r *ReconcileAPI, swagger *openapi3.Swagger, mode string, 
 									isServiceDef = true
 								}
 							} else {
-									endpointNames[endpointUrl.Hostname()] = endpointUrl.Hostname()
+								endpointNames[endpointUrl.Hostname()] = endpointUrl.Hostname()
 							}
 						}
 
@@ -1204,8 +1204,8 @@ func mgwSwaggerHandler(r *ReconcileAPI, swagger *openapi3.Swagger, mode string, 
 		}
 	}
 	for pathName, path := range mgwSwagger.Paths {
-		for mapPath, value := range resLevelEp{
-			if strings.EqualFold(pathName,mapPath) {
+		for mapPath, value := range resLevelEp {
+			if strings.EqualFold(pathName, mapPath) {
 				path.Get.Extensions[endpointExtension] = value
 			}
 		}

--- a/apim-operator/pkg/controller/api/api_controller.go
+++ b/apim-operator/pkg/controller/api/api_controller.go
@@ -1021,7 +1021,6 @@ func mgwSwaggerHandler(r *ReconcileAPI, swagger *openapi3.Swagger, mode string, 
 	var editedSwaggerData string
 	var mgwSwagger *openapi3.Swagger
 	var errMgwSwgr error
-	//var resLevelEp = make(map[*openapi3.PathItem]XMGWProductionEndpoints)
 	var resLevelEp = make(map[string]XMGWProductionEndpoints)
 	mapName := apiName + "-swagger-mgw"
 	//get mgw swagger if available
@@ -1069,7 +1068,6 @@ func mgwSwaggerHandler(r *ReconcileAPI, swagger *openapi3.Swagger, mode string, 
 					log.Error(err, "Error in getting targetendpoint CRD object")
 				} else {
 					protocol := targetEndpointCr.Spec.Protocol
-					//endpointNames[endPoint] = endPoint
 					if mode == sidecar {
 						endPointSidecar := protocol + "://" + "localhost:" + strconv.Itoa(int(targetEndpointCr.Spec.Port))
 						endpointNames[targetEndpointCr.Name] = endPointSidecar
@@ -1448,9 +1446,6 @@ func isImageExist(image string, tag string, r *ReconcileAPI) (bool, error) {
 //Schedule Kaniko Job to generate micro-gw image
 func scheduleKanikoJob(cr *wso2v1alpha1.API, imageName string, conf *corev1.ConfigMap, jobVolumeMount []corev1.VolumeMount,
 	jobVolume []corev1.Volume, timeStamp string, owner []metav1.OwnerReference) *batchv1.Job {
-	//labels := map[string]string{
-	//	"app": cr.Name,
-	//}
 	kanikoJobName := cr.Name + "kaniko"
 	if timeStamp != "" {
 		kanikoJobName = kanikoJobName + "-" + timeStamp
@@ -1774,7 +1769,6 @@ func getAnalyticsPVClaim(r *ReconcileAPI, deployVolumeMount []corev1.VolumeMount
 			},
 		},
 	}
-	//}
 	return deployVolumeMount, deployVolume, nil
 }
 


### PR DESCRIPTION
## Purpose
> Earlier we added modifications which are required for mgw to the original swagger directly. So need to keep original one as it is in a configmap and edited swagger will keep in separate configmap. 
> Resource level endpoints should be replaced with localhost when the deployment is defined as sidecar.  

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.