### PR TITLE
Fix the controller looping when the operator is not in wso2-system namespace

### DIFF
--- a/apim-operator/pkg/controller/api/api_controller.go
+++ b/apim-operator/pkg/controller/api/api_controller.go
@@ -176,7 +176,7 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	owner := getOwnerDetails(instance)
 	operatorOwner, ownerErr := getOperatorOwner(r)
 	if ownerErr != nil {
-		return reconcile.Result{}, ownerErr
+		reqLogger.Info("Operator was not found in the "+wso2NameSpaceConst+" namespace. No owner will be set for the artifacts")
 	}
 	userNameSpace := instance.Namespace
 

--- a/apim-operator/pkg/controller/ratelimiting/ratelimiting_controller.go
+++ b/apim-operator/pkg/controller/ratelimiting/ratelimiting_controller.go
@@ -125,7 +125,7 @@ func (r *ReconcileRateLimiting) Reconcile(request reconcile.Request) (reconcile.
 	//gets the details of the operator as the owner
 	operatorOwner, ownerErr := getOperatorOwner(r)
 	if ownerErr != nil {
-		return reconcile.Result{}, ownerErr
+		reqLogger.Info("Operator was not found in the "+wso2NameSpaceConst+" namespace. No owner will be set for the artifacts")
 	}
 
 	// GENERATE POLICY YAML USING CRD INSTANCE
@@ -239,7 +239,7 @@ func (r *ReconcileRateLimiting) Reconcile(request reconcile.Request) (reconcile.
 
 }
 
-// CreateConfigMap creates a config file with the generated code
+//CreatePolicyConfigMap creates a config file with the generated code
 func CreatePolicyConfigMap(output string, operatorOwner []metav1.OwnerReference, userNameSpace string) (*corev1.ConfigMap, error) {
 
 	return &corev1.ConfigMap{
@@ -254,7 +254,7 @@ func CreatePolicyConfigMap(output string, operatorOwner []metav1.OwnerReference,
 	}, nil
 }
 
-//Check if the policy already exists in the existing policy map
+//IsPolicyExist checks if the policy already exists in the existing policy map
 func IsPolicyExist(policyArrayMap []map[string]Policy, name string) bool {
 
 	oldPolicies := policyArrayMap[0]


### PR DESCRIPTION
Fix #186 
When the apim-operator is deployed in a namespace other than wso2-system, the controllers run in an error loop forever when a custom resource is deployed.
This PR fixes it.