### PR TITLE
Improve analytics dashboard deployment in k8s

### DIFF
--- a/k8s-artifacts/api-portal-with-analytics/api-analytics/analytics-dashboard-deployment.yaml
+++ b/k8s-artifacts/api-portal-with-analytics/api-analytics/analytics-dashboard-deployment.yaml
@@ -33,6 +33,13 @@ spec:
       labels:
         deployment: wso2apim-dashboard-analytics
     spec:
+      initContainers:
+        - name: init-wait-sql
+          image: alpine
+          command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 wso2apim-with-analytics-rdbms-service 3306 && exit 0 || sleep 3; done; exit 1"]
+        - name: init-wait-api-portal
+          image: alpine
+          command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 wso2apim 32001 && exit 0 || sleep 3; done; exit 1"]
       containers:
         - name: wso2apim-dashboard-analytics
           image: wso2/wso2am-analytics-dashboard:3.0.0


### PR DESCRIPTION
Fixes #185 

When the API portal pod or mysql services are not available, the analytics dashboard is not accessible although the analytics dashboard pod status is displayed as 'Ready'.
To make it easier for the user to debug,this PR keeps the analytics dashboard in init state when the api portal or mysql is not available. When the api portal and mysql services are available the dashboard is put to ready state.